### PR TITLE
Add video transcoder module, initially designed for SpaceX Falcon 9 stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(APPLE)
 endif()
 
 if(UNIX)
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra")
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -DUSE_VIDEO_ENCODER")
     set(CMAKE_CXX_FLAGS_DEBUG "-g")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 else()

--- a/src-core/CMakeLists.txt
+++ b/src-core/CMakeLists.txt
@@ -26,6 +26,10 @@ if(MSVC)
     target_link_libraries(satdump_core PUBLIC volk.dll)
     target_link_libraries(satdump_core PUBLIC libpng16.dll)
     target_link_libraries(satdump_core PUBLIC fftw3f.dll)
+    target_link_libraries(satdump_core PUBLIC libavcodec.dll)
+    target_link_libraries(satdump_core PUBLIC libavformat.dll)
+    target_link_libraries(satdump_core PUBLIC libavutil.dll)
+    target_link_libraries(satdump_core PUBLIC libavfilter.dll)
     #target_link_libraries(satdump_core PUBLIC stdc++fs)
 else()
     # LibDSP
@@ -45,10 +49,26 @@ else()
     target_include_directories(satdump_core PUBLIC ${fmt_INCLUDE_DIRS})
     target_link_libraries(satdump_core PUBLIC fmt::fmt)
 
-    # FMT
+    # VOLK
     pkg_check_modules(VOLK REQUIRED volk)
     target_include_directories(satdump_core PUBLIC ${volk_INCLUDE_DIRS})
     target_link_libraries(satdump_core PUBLIC volk)
+
+    # libavcodec
+    find_library(AVCODEC_LIBRARY avcodec REQUIRED)
+    target_link_libraries(satdump_core PUBLIC ${AVCODEC_LIBRARY})
+
+    # libavformat
+    find_library(AVFORMAT_LIBRARY avformat REQUIRED)
+    target_link_libraries(satdump_core PUBLIC ${AVFORMAT_LIBRARY})
+
+    # libavutil
+    find_library(AVUTIL_LIBRARY avutil REQUIRED)
+    target_link_libraries(satdump_core PUBLIC ${AVUTIL_LIBRARY})
+
+    # libavfilter
+    find_library(AVFILTER_LIBRARY avfilter REQUIRED)
+    target_link_libraries(satdump_core PUBLIC ${AVFILTER_LIBRARY})
 
     # LibPNG
     if(WIN32 AND NOT MINGW)
@@ -69,5 +89,7 @@ else()
         target_link_libraries(satdump_core PUBLIC stdc++fs)
     endif()
 
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_DEBUG "-ggdb")
     
 endif()

--- a/src-core/modules/spacex/falcon_video_encoder.cpp
+++ b/src-core/modules/spacex/falcon_video_encoder.cpp
@@ -1,0 +1,607 @@
+/*
+ * This file is part of the SatDump
+ *
+ * Autors:
+ *   Oleg Kutkov <contact@olegkutkov.me>
+ * 
+ * This program is free software: you can redistribute it and/or modify  
+ * it under the terms of the GNU General Public License as published by  
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but 
+ * WITHOUT ANY WARRANTY; without even the implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License 
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef USE_VIDEO_ENCODER
+
+extern "C" {
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libavfilter/avfilter.h>
+#include <libavfilter/buffersink.h>
+#include <libavfilter/buffersrc.h>
+#include <libavutil/opt.h>
+#include <stdio.h>
+}
+
+#include <algorithm>
+#include <stdexcept>
+
+#include "falcon_video_encoder.hpp"
+#include "logger.h"
+
+///
+
+#define TS_SYNC_BYTE 0x47
+#define TS_DATA_START 0x40
+#define AVIO_BUF_SIZE 204800
+
+static const std::string overlay_file = "telemetry_overlat.txt";
+static const std::string overlay_params = ":reload=1:x=15:y=310:fontsize=15:fontcolor=white";
+
+///
+
+namespace spacex
+{
+    FalconVideoEncoder::FalconVideoEncoder(std::string out_dir)
+        : io_ctx(NULL)
+        , in_ctx(NULL)
+        , filter_ctx(NULL)
+        , avio_buf_len(AVIO_BUF_SIZE)
+        , avio_buf(static_cast<uint8_t *> (av_malloc(AVIO_BUF_SIZE)))
+        , buffersrc(avfilter_get_by_name("buffer"))
+        , buffersink(avfilter_get_by_name("buffersink"))
+        , out_directory(out_dir)
+        , overlay_txt_file(out_dir + "/" + overlay_file)
+        , filter_desc("drawtext=textfile='" + overlay_txt_file + "'" + overlay_params)
+        , data_found(false)
+        , decoder_started(false)
+    {
+        if (!avio_buf) {
+            throw std::runtime_error("Failed to allocate avio buffer\n");
+        }
+
+        stream_buffer.reserve(AVIO_BUF_SIZE);
+
+        io_ctx = avio_alloc_context(avio_buf, avio_buf_len, 0, &stream_buffer
+                                    , &FalconVideoEncoder::avReader, NULL, NULL);
+
+        if (!io_ctx) {
+            throw std::runtime_error("Failed to allocate avio context\n");
+        }
+
+        io_ctx->max_packet_size = avio_buf_len;
+        in_ctx = avformat_alloc_context();
+        in_ctx->pb = io_ctx;
+
+        memset(avio_buf, 0, AVIO_BUF_SIZE);
+
+        av_log_set_callback(FalconVideoEncoder::libraryLogger);
+
+        overlay.open(overlay_txt_file, std::ios::out | std::ios::trunc);
+
+        if (!overlay.is_open()) {
+            throw std::runtime_error("Failed to open overlay text file\n");
+        }
+    }
+
+    FalconVideoEncoder::~FalconVideoEncoder()
+    {
+        if (in_ctx) {
+            avformat_close_input(&in_ctx);
+            avformat_free_context(in_ctx);
+        }
+
+        if (io_ctx) {
+            av_free(io_ctx);
+        }
+ 
+        overlay.close();
+        remove(overlay_txt_file.c_str());
+
+        for (std::pair<uint32_t, AVCodecContext*> dec : video_decoders) {
+            avcodec_free_context(&dec.second);
+        }
+
+        for (std::pair<uint32_t, AVCodecContext*> enc : video_encoders) {
+            avcodec_free_context(&enc.second);
+        }
+
+        for (std::pair<uint32_t, VideoFilter> filter : video_filters) {
+            avfilter_graph_free(&filter.second.filter_graph);
+        }
+    }
+
+    void FalconVideoEncoder::pushTelemetryText(std::string text)
+    {
+        overlay.seekp(0);
+        overlay << text << std::endl;
+    }
+
+    void FalconVideoEncoder::libraryLogger(void *ptr, int level, const char* fmt, va_list vl)
+    {
+        (void) ptr;
+        char str[1024] = { 0 };
+
+        vsnprintf(str, sizeof(str), fmt, vl);
+        str[strlen(str) - 1] = '\0';
+
+        switch (level) {
+            case AV_LOG_PANIC:
+            case AV_LOG_FATAL:
+                logger->critical(str);
+                break;
+
+            case AV_LOG_ERROR:
+                logger->error(str);
+                break;
+
+            case AV_LOG_INFO:
+                logger->info(str);
+                break;
+
+            case AV_LOG_WARNING:
+                logger->warn(str);
+                break;
+
+            case AV_LOG_DEBUG:
+                logger->debug(str);
+                break;
+
+            default:
+                logger->trace(std::string("FalconVideoEncoder: ") + str);
+        };
+    }
+
+    bool FalconVideoEncoder::feedData(std::vector<uint8_t>::const_iterator &data_chunk_start,
+                                        std::vector<uint8_t>::const_iterator &data_chunk_end)
+    {
+        if ((stream_buffer.size() + std::distance(data_chunk_start, data_chunk_end)) < AVIO_BUF_SIZE) {
+            stream_buffer.insert(stream_buffer.begin() + stream_buffer.size(), data_chunk_start, data_chunk_end);
+            return true;
+        }
+
+        if (!decoder_started) {
+            decoder_started = initDecoder();
+
+            if (!decoder_started) {
+                stream_buffer.clear();
+                return false;
+            }
+        }
+
+        frameWorker();
+
+        stream_buffer.clear();
+
+        return true;
+    }
+
+    bool FalconVideoEncoder::streamFinished()
+    {
+        if (!decoder_started && stream_buffer.size()) {
+            decoder_started = initDecoder();
+
+            if (decoder_started) {
+                frameWorker();
+                stream_buffer.clear();
+            }
+        }
+
+        if (decoder_started) {
+            for (std::pair<uint32_t, AVFormatContext*> out_fmt_ctx : video_out_ctx) {
+                av_write_trailer(out_fmt_ctx.second);
+                avio_closep(&(out_fmt_ctx.second->pb));
+                avformat_free_context(out_fmt_ctx.second);
+            }
+        }
+
+        return true;
+    }
+////
+
+    int FalconVideoEncoder::avReader(void *opaque, uint8_t *buf, int buf_size)
+    {
+        std::vector<uint8_t> *sb = (std::vector<uint8_t> *) opaque;
+
+        buf_size = sb->size();
+
+        if (sb->size()) {
+            std::copy(sb->begin(), sb->end(), buf);
+            sb->clear();
+        }
+
+        return buf_size;
+    }
+
+    bool FalconVideoEncoder::initDecoder()
+    {
+        int ret = avformat_open_input(&in_ctx, "VIDEO", NULL, NULL);
+
+        if (ret < 0) {
+            logger->error("avformat_open_input() failed!");
+            return false;
+        }
+
+        if (avformat_find_stream_info(in_ctx, NULL) < 0) {
+             logger->error("Failed to find stream info");
+            return false;
+        }
+
+        for (uint32_t i = 0; i < in_ctx->nb_streams; i++) {
+            AVStream *stream = in_ctx->streams[i];
+
+            if (stream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+                AVCodec *dec = avcodec_find_decoder(stream->codecpar->codec_id);
+
+                if (!dec) {
+                    logger->error("Couldn't find decoder for stream #" + std::to_string(i));
+                    return false;
+                }
+
+                AVCodecContext *codec_ctx = avcodec_alloc_context3(dec);
+
+                if (!codec_ctx) {
+                    logger->error("AVCODEC context allocation failed");
+                    return false;
+                }
+
+                if (avcodec_parameters_to_context(codec_ctx, stream->codecpar) < 0) {
+                    logger->error("Failed to copy decoder parameters to input decoder context");
+                    return false;
+                }
+
+                logger->info("Found Video stream, id = " + std::to_string(i));
+
+                codec_ctx->framerate = av_guess_frame_rate(in_ctx, stream, NULL);
+
+                if (avcodec_open2(codec_ctx, avcodec_find_decoder(codec_ctx->codec_id), NULL) < 0) {
+                    logger->error("Can't open decoder for the stream");
+                    return false;
+                }
+
+                video_decoders[i] = codec_ctx;
+
+            } else if (stream->codecpar->codec_type == AVMEDIA_TYPE_DATA) {
+                if (stream->codecpar->codec_id == AV_CODEC_ID_SMPTE_KLV) {
+                    logger->info("Found KLV data stream, id = " + std::to_string(i));
+                    klv_streams[i].open(buildOutFileName(i, "data", "klv").c_str());
+                }
+            } 
+        }
+
+        av_dump_format(in_ctx, 0, "STREAM", 0);
+
+        if (!configureVideoOutput()) {
+            return false;
+        }
+
+        if (!configureVideoFilters()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    std::string FalconVideoEncoder::buildOutFileName(uint32_t stream_id, const char *base, const char *ext)
+    {
+        std::string result = out_directory + "/" + base + "_" + std::to_string(stream_id) + "." + ext;
+        return result;
+    }
+
+    bool FalconVideoEncoder::configureVideoOutput()
+    {
+        AVStream *out_stream;
+        AVFormatContext *out_ctx;
+        AVCodecContext *enc_ctx;
+        AVCodec *encoder;
+
+        for (std::pair<uint32_t, AVCodecContext*> dec_ctx : video_decoders) {
+            std::string out_file = buildOutFileName(dec_ctx.first, "video", "mp4");
+
+            avformat_alloc_output_context2(&out_ctx, NULL, NULL, out_file.c_str());
+
+            if (!out_ctx) {
+                logger->error("Failed to create output context file " + out_file);
+                continue;
+            }
+
+            encoder = avcodec_find_encoder(dec_ctx.second->codec_id);
+
+            if (!encoder) {
+                logger->error("Failed to find encoder for stream #" + std::to_string(dec_ctx.first));
+                continue;
+            }
+
+            out_stream = avformat_new_stream(out_ctx, encoder);
+
+            if (!out_stream) {
+                logger->error("Failed allocating output stream " + out_file);
+                continue;
+            }
+
+            enc_ctx = avcodec_alloc_context3(encoder);
+
+            if (!enc_ctx) {
+                logger->error("Failed to allocate the encoder context for " + out_file);
+                continue;
+            }
+
+            enc_ctx->width = dec_ctx.second->width;
+            enc_ctx->height = dec_ctx.second->height;
+            enc_ctx->sample_aspect_ratio = dec_ctx.second->sample_aspect_ratio;
+
+            if (encoder->pix_fmts) {
+                enc_ctx->pix_fmt = encoder->pix_fmts[0];
+            } else {
+                enc_ctx->pix_fmt = dec_ctx.second->pix_fmt;
+            }
+
+            enc_ctx->time_base = av_inv_q(dec_ctx.second->framerate);
+
+            if (out_ctx->oformat->flags & AVFMT_GLOBALHEADER) {
+                enc_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+            }
+
+            if (avcodec_open2(enc_ctx, encoder, NULL) < 0) {
+                logger->error("Couldn't open video encoder for stream #" + std::to_string(dec_ctx.first));
+                continue;
+            }
+
+            avcodec_parameters_from_context(out_stream->codecpar, enc_ctx);
+
+            out_stream->time_base = enc_ctx->time_base;
+
+            if (avio_open(&out_ctx->pb, out_file.c_str(), AVIO_FLAG_WRITE) < 0) {
+                logger->error("Couldn't create output file " + out_file);
+                continue;
+            }
+
+            if (avformat_write_header(out_ctx, NULL) < 0) {
+                logger->error("Unable to write AV header to " + out_file);
+                continue;
+            }
+
+            logger->info("Writing Video #" + std::to_string(dec_ctx.first) + " to " + out_file);
+
+            video_encoders[dec_ctx.first] = enc_ctx;
+            video_out_ctx[dec_ctx.first] = out_ctx;
+
+            av_dump_format(out_ctx, 0, out_file.c_str(), 1);
+        }
+  
+       return true;
+    }
+
+    bool FalconVideoEncoder::configureVideoFilters()
+    {
+        char args[512];
+
+        for (std::pair<uint32_t, AVCodecContext*> dec_ctx : video_decoders) {
+            AVFilterGraph *fgraph = avfilter_graph_alloc();
+
+            if (!fgraph) {
+                logger->error("Failed to allocate filter graph");
+                return false;
+            }
+
+            AVStream *stream = in_ctx->streams[dec_ctx.first];
+            AVFilterInOut *outputs = avfilter_inout_alloc();
+            AVFilterInOut *inputs  = avfilter_inout_alloc();
+
+            if (!outputs || !inputs) {
+                logger->error("Failed to allocate filter inputs and outputs");
+                return false;
+            }
+
+            AVRational time_base = stream->time_base;
+
+            snprintf(args, sizeof(args),
+              "video_size=%dx%d:pix_fmt=%d:time_base=%d/%d:pixel_aspect=%d/%d",
+                dec_ctx.second->width, dec_ctx.second->height, dec_ctx.second->pix_fmt,
+                time_base.num, time_base.den,
+                dec_ctx.second->sample_aspect_ratio.num, dec_ctx.second->sample_aspect_ratio.den);
+
+            AVFilterContext *buffersrc_ctx;
+            AVFilterContext *buffersink_ctx;
+
+            if (avfilter_graph_create_filter(&buffersrc_ctx, buffersrc, "in", args, NULL, fgraph) < 0) {
+                logger->error("Cannot create filter buffer source");
+                return false;
+            }
+
+            if (avfilter_graph_create_filter(&buffersink_ctx, buffersink, "out", NULL, NULL, fgraph) < 0) {
+                logger->error("Cannot create filter buffer sink");
+                return false;
+            }
+
+            outputs->name = av_strdup("in");
+            outputs->filter_ctx = buffersrc_ctx;
+            outputs->pad_idx = 0;
+            outputs->next = NULL;
+
+            inputs->name = av_strdup("out");
+            inputs->filter_ctx = buffersink_ctx;
+            inputs->pad_idx = 0;
+            inputs->next = NULL;
+
+            if (avfilter_graph_parse_ptr(fgraph, filter_desc.c_str(), &inputs, &outputs, NULL) < 0) {
+                logger->error("avfilter_graph_parse_ptr fail");
+                return false;
+            }
+
+            if (avfilter_graph_config(fgraph, NULL) < 0) {
+                logger->error("avfilter_graph_config failed");
+                return false;
+            }
+
+            video_filters[dec_ctx.first] = { buffersrc_ctx, buffersink_ctx, fgraph };
+        }
+
+        return true;
+    }
+
+    bool FalconVideoEncoder::frameDecoder(AVCodecContext *avctx, AVFrame *frame, int *got_frame, AVPacket *pkt)
+    {
+        int ret;
+        *got_frame = 0;
+
+        if (pkt) {
+            ret = avcodec_send_packet(avctx, pkt);
+
+            if (ret < 0 && ret != AVERROR_EOF) {
+                return false;
+            }
+        }
+
+        ret = avcodec_receive_frame(avctx, frame);
+
+        if (ret < 0 && ret != AVERROR(EAGAIN)) {
+            return false;
+        }
+
+        if (ret >= 0) {
+            *got_frame = 1;
+        }
+
+        return true;
+    }
+
+    bool FalconVideoEncoder::frameWorker()
+    {
+        AVPacket packet;
+        AVPacket enc_pkt;
+
+        std::unordered_map<uint32_t, AVCodecContext*>::iterator dec_it;
+        std::unordered_map<uint32_t, AVCodecContext*>::iterator enc_it;
+        std::unordered_map<uint32_t, AVFormatContext*>::iterator out_ctx_it;
+        std::unordered_map<uint32_t, VideoFilter>::iterator vfilter_it;
+        std::unordered_map<uint32_t, std::ofstream>::iterator klv_it;
+
+        AVCodecContext *dec;
+        AVCodecContext *enc;
+        AVFormatContext *out_ctx;
+
+        int got_frame = 0, ret = 0;
+
+        AVFrame *frame = av_frame_alloc();
+        AVFrame *filt_frame = av_frame_alloc();
+
+        if (!frame || !filt_frame) {
+            logger->error("Couldn't allocate frame");
+            return false;
+        }
+
+        av_init_packet(&packet);
+
+        while (av_read_frame(in_ctx, &packet) >= 0) {
+            uint32_t stream_id = packet.stream_index;
+            dec_it = video_decoders.find(stream_id);
+
+            /* Found decoder for the stream */
+            if (dec_it != video_decoders.end()) {
+
+                enc_it = video_encoders.find(stream_id);
+
+                if (enc_it == video_encoders.end()) {
+                    logger->error("Can't find video encoder for stream #" + std::to_string(stream_id));
+                    return false;
+                }
+
+                out_ctx_it = video_out_ctx.find(stream_id);
+
+                if (out_ctx_it == video_out_ctx.end()) {
+                    logger->error("Can't find output context for stream #" + std::to_string(stream_id));
+                    return false;
+                }
+
+                vfilter_it = video_filters.find(stream_id);
+
+                if (vfilter_it == video_filters.end()) {
+                    logger->error("Can't find video filter for stream #" + std::to_string(stream_id));
+                    return false;
+                }
+
+                dec = dec_it->second;
+                enc = enc_it->second;
+                out_ctx = out_ctx_it->second;
+
+                av_packet_rescale_ts(&packet, in_ctx->streams[stream_id]->time_base, dec->time_base);
+
+                if (!frameDecoder(dec, frame, &got_frame, &packet)) {
+                    logger->error("Stream #" + std::to_string(stream_id) + " decoder failed");
+                    return false;
+                }
+
+                if (frame_counters.find(stream_id) == frame_counters.end()) {
+                    frame_counters[stream_id] = 0;
+                }
+
+                frame->pts = frame_counters[stream_id]++;
+
+                if (got_frame) {
+
+                    if (av_buffersrc_add_frame_flags(vfilter_it->second.buf_src_ctx, frame
+                                                    , AV_BUFFERSRC_FLAG_KEEP_REF) < 0) {
+                        logger->error("Error while feeding the filtergraph");
+                        continue;
+                    }
+
+                    while (1) {
+                        ret = av_buffersink_get_frame(vfilter_it->second.buf_sink_ctx, filt_frame);
+
+                        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+                            break;
+                        } else if (ret < 0) {
+                            return -1;
+                        }
+
+                        if (avcodec_send_frame(enc, filt_frame) < 0) {
+                            break;
+                        }
+
+                        av_init_packet(&enc_pkt);
+
+                        while (ret >= 0) {
+                            ret = avcodec_receive_packet(enc, &enc_pkt);
+
+                            if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+                                break;
+                            } else if (ret < 0) {
+                                logger->error("Encoder failure! Stream #" + std::to_string(stream_id));
+                                return false;
+                            }
+
+                            enc_pkt.stream_index = 0;
+                            av_packet_rescale_ts(&enc_pkt, enc->time_base, out_ctx->streams[0]->time_base);
+
+                            av_interleaved_write_frame(out_ctx, &enc_pkt);
+                        } /* while */
+                    } /* while(1) */
+                } /* got_frame */
+
+            } else { /* Data */
+                klv_it = klv_streams.find(stream_id);
+
+                if (klv_it != klv_streams.end()) {
+                    klv_it->second.write(reinterpret_cast<const char*> (packet.data), packet.size);
+                }
+            }
+
+            av_packet_unref(&packet);
+        }
+
+        av_frame_unref(frame);
+        av_frame_unref(filt_frame);
+
+        return true;
+    }
+
+} // namespace spacex
+
+#endif // USE_VIDEO_ENCODER

--- a/src-core/modules/spacex/falcon_video_encoder.hpp
+++ b/src-core/modules/spacex/falcon_video_encoder.hpp
@@ -1,0 +1,110 @@
+/*
+ * This file is part of the SatDump
+ *
+ * Autors:
+ *   Oleg Kutkov <contact@olegkutkov.me>
+ * 
+ * This program is free software: you can redistribute it and/or modify  
+ * it under the terms of the GNU General Public License as published by  
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but 
+ * WITHOUT ANY WARRANTY; without even the implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License 
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FALCON_VIDEO_ENCODER_HPP
+#define FALCON_VIDEO_ENCODER_HPP
+
+#ifdef USE_VIDEO_ENCODER
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <fstream>
+#include <iostream>
+
+class AVIOContext;
+class AVFormatContext;
+class AVCodecContext;
+class AVFilterContext;
+class AVFilterGraph;
+class AVFilter;
+class AVPacket;
+class AVFrame;
+
+namespace spacex
+{
+    class FalconVideoEncoder
+    {
+    public:
+        FalconVideoEncoder(std::string out_dir);
+        ~FalconVideoEncoder();
+
+        bool feedData(std::vector<uint8_t>::const_iterator &data_chunk_start,
+                        std::vector<uint8_t>::const_iterator &data_chunk_end);
+        bool processData();
+        bool streamFinished();
+
+        void pushTelemetryText(std::string text);
+
+    private:
+        bool initDecoder();
+
+        static void libraryLogger(void *ptr, int level, const char *fmt, va_list vl);
+
+        static int avReader(void *opaque, uint8_t *buf, int buf_size);
+
+        bool configureVideoOutput();
+        bool configureVideoFilters();
+
+        bool frameDecoder(AVCodecContext *avctx, AVFrame *frame, int *got_frame, AVPacket *pkt);
+        bool frameWorker();
+
+        std::string buildOutFileName(uint32_t stream_id, const char *base, const char *ext);
+
+////
+        struct VideoFilter {
+            AVFilterContext *buf_src_ctx;
+            AVFilterContext *buf_sink_ctx;
+            AVFilterGraph *filter_graph;
+        };
+
+        AVIOContext *io_ctx;
+        AVFormatContext *in_ctx;
+        AVFilterContext *filter_ctx;
+ 
+        size_t avio_buf_len;
+        uint8_t *avio_buf;
+
+        const AVFilter *buffersrc;
+        const AVFilter *buffersink;
+
+        std::string out_directory;
+        std::string overlay_txt_file;
+        std::string filter_desc;
+
+        bool data_found;
+        bool decoder_started;
+
+        std::vector<uint8_t> stream_buffer;
+
+        /// key - stream ID
+        std::unordered_map<uint32_t, AVCodecContext*> video_decoders;
+        std::unordered_map<uint32_t, AVCodecContext*> video_encoders;
+        std::unordered_map<uint32_t, AVFormatContext*> video_out_ctx;
+        std::unordered_map<uint32_t, VideoFilter> video_filters;
+        std::unordered_map<uint32_t, std::ofstream> klv_streams;
+
+        std::unordered_map<uint32_t, uint32_t> frame_counters;
+
+        std::ofstream overlay;
+    };
+}
+
+#endif // USE_VIDEO_ENCODER
+#endif // FALCON_VIDEO_ENCODER_HPP

--- a/src-core/modules/spacex/module_falcon_decoder.cpp
+++ b/src-core/modules/spacex/module_falcon_decoder.cpp
@@ -4,6 +4,21 @@
 #include "imgui/imgui.h"
 #include "demuxer.h"
 
+#define FALCON_CADU_FRAME_SIZE 0x4FF // 1279 bytes
+
+#define STREAM_HEADER_SKIP   0x19 // 25 bytes
+
+#define MAGIC_MARKER_VIDEO_STREAM  0x01123201042E1403
+#define VIDEO_STREAM_MIN_DATA_SIZE 0x3C5  // 965 bytes
+
+#define MAGIC_MARKER0_GPS_DEBUG 0x0117FE0800320303
+#define MAGIC_MARKER1_GPS_DEBUG 0x0112FA0800320303
+
+#define MAGIC_MARKER_SFC1A_DEBUG   0x0112220100620303
+#define MAGIC_MARKER_SFTMM1A_DEBUG 0x0112520100620303
+#define MAGIC_MARKER_SFTMM1C_DEBUG 0x0112720100620303
+
+
 // Return filesize
 size_t getFilesize(std::string filepath);
 
@@ -26,11 +41,15 @@ namespace spacex
 
         std::string directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/'));
 
+#ifdef USE_VIDEO_ENCODER
+        this->videoStreamEnc = std::unique_ptr<FalconVideoEncoder>(new FalconVideoEncoder(directory));
+#else
         std::ofstream video_out = std::ofstream(directory + "/camera.mxf", std::ios::binary);
         d_output_files.push_back(directory + "/camera.mxf");
         logger->info("Decoding to " + directory + "/camera.mxf");
         logger->warn("This MXF (MPEG) video stream may need to be converted to be usable. GStreamer is recommended as it gives significantly better results than most other software!");
         logger->warn("gst-launch-1.0 filesrc location=\"camera.mxf\" ! decodebin ! videoconvert ! avimux name=mux ! filesink location=camera.avi");
+#endif
 
         std::ofstream gps_debug_out = std::ofstream(directory + "/gps_debug.txt");
         d_output_files.push_back(directory + "/gps_debug.txt");
@@ -58,13 +77,16 @@ namespace spacex
 
         time_t lastTime = 0;
 
-        uint8_t cadu[1279];
+        uint8_t cadu[FALCON_CADU_FRAME_SIZE];
         Demuxer demux;
+
+        std::string gps_raw_txt, gps_tmp;
+        uint64_t gps_date_num;
 
         while (!data_in.eof())
         {
             // Read buffer
-            data_in.read((char *)cadu, 1279);
+            data_in.read((char *)cadu, FALCON_CADU_FRAME_SIZE);
 
             std::vector<SpaceXPacket> frames = demux.work(cadu);
 
@@ -75,52 +97,86 @@ namespace spacex
                                   ((uint64_t)pkt.payload[6]) << 24 | ((uint64_t)pkt.payload[7]) << 16 |
                                   ((uint64_t)pkt.payload[8]) << 8 | ((uint64_t)pkt.payload[9]);
 
-                if (marker == 0x01123201042E1403 && pkt.payload.size() >= 965.0)
-                {
-                    video_out.write((char *)&pkt.payload[25], 965.0 - 25);
-                }
-                else if (marker == 0x0117FE0800320303 || marker == 0x0112FA0800320303)
-                {
-                    pkt.payload[pkt.payload.size() - 1] = 0;
-                    pkt.payload[pkt.payload.size() - 2] = 0;
-                    gps_debug_out << std::string((char *)&pkt.payload[25]) << std::endl;
-                }
-                else if (marker == 0x0112220100620303)
-                {
-                    pkt.payload[pkt.payload.size() - 1] = 0;
-                    pkt.payload[pkt.payload.size() - 2] = 0;
-                    sfc1a_debug << std::string((char *)&pkt.payload[25]) << std::endl;
-                }
-                else if (marker == 0x0112520100620303)
-                {
-                    pkt.payload[pkt.payload.size() - 1] = 0;
-                    pkt.payload[pkt.payload.size() - 2] = 0;
-                    sftmm1a_debug << std::string((char *)&pkt.payload[25]) << std::endl;
-                }
-                else if (marker == 0x0112520100620303)
-                {
-                    pkt.payload[pkt.payload.size() - 1] = 0;
-                    pkt.payload[pkt.payload.size() - 2] = 0;
-                    sftmm1b_debug << std::string((char *)&pkt.payload[25]) << std::endl;
-                }
-                else if (marker == 0x0112720100620303)
-                {
-                    pkt.payload[pkt.payload.size() - 1] = 0;
-                    pkt.payload[pkt.payload.size() - 2] = 0;
-                    sftmm1c_debug << std::string((char *)&pkt.payload[25]) << std::endl;
-                }
+                size_t payload_size = pkt.payload.size();
 
-                // if (marker == 0x0012FA08D0480108)
-                // {
-                // logger->info(pkt.payload.size());
+                /* Use switch:case for the faster processing */
+                switch (marker)
+                {
+                    case MAGIC_MARKER_VIDEO_STREAM:
+                        if (payload_size >= VIDEO_STREAM_MIN_DATA_SIZE)
+                        {
+                            const uint8_t *vframe = static_cast<const uint8_t*>(&pkt.payload[STREAM_HEADER_SKIP]);
+                            size_t vframe_size = VIDEO_STREAM_MIN_DATA_SIZE - STREAM_HEADER_SKIP;
 
-                //     data_out.put(0x1a);
-                //     data_out.put(0xcf);
-                //      data_out.put(0xfc);
-                //      data_out.put(0x1d);
-                //      data_out.write((char *)pkt.payload.data(), pkt.payload.size());
-                // }
+#ifdef USE_VIDEO_ENCODER
+                            std::vector<uint8_t>::const_iterator vframe_start = pkt.payload.begin() + STREAM_HEADER_SKIP;
+                            std::vector<uint8_t>::const_iterator vframe_end = vframe_start + vframe_size;
+
+                            videoStreamEnc->feedData(vframe_start, vframe_end);
+#else
+                            video_out.write(reinterpret_cast<const char*> (vframe), vframe_size);
+#endif
+                        }
+                        break;
+
+                    case MAGIC_MARKER0_GPS_DEBUG:
+                    case MAGIC_MARKER1_GPS_DEBUG:
+                        pkt.payload[pkt.payload.size() - 1] = 0;
+                        pkt.payload[pkt.payload.size() - 2] = 0;
+
+                        gps_raw_txt = std::string((char *)&pkt.payload[STREAM_HEADER_SKIP]);
+
+#ifdef USE_VIDEO_ENCODER
+                        if (gps_raw_txt.length() >= 85) {
+                            if (gps_raw_txt[19] == '>') {
+                                gps_tmp = gps_raw_txt.substr(0, 18);
+
+                                gps_date_num = atol(gps_tmp.c_str());
+
+                                gps_tmp = "GPS timestamp: " + gps_tmp + "\nMessage: "
+                                        + gps_raw_txt.substr(20, gps_raw_txt.size() - 20);
+
+                                videoStreamEnc->pushTelemetryText(gps_tmp);
+                            }
+                        }
+#endif
+                        gps_debug_out << gps_raw_txt << std::endl;
+                        break;
+
+                    case MAGIC_MARKER_SFC1A_DEBUG:
+                        pkt.payload[pkt.payload.size() - 1] = 0;
+                        pkt.payload[pkt.payload.size() - 2] = 0;
+                        sfc1a_debug << std::string((char *)&pkt.payload[STREAM_HEADER_SKIP]) << std::endl;
+                        break;
+
+                    case MAGIC_MARKER_SFTMM1A_DEBUG:
+                        pkt.payload[pkt.payload.size() - 1] = 0;
+                        pkt.payload[pkt.payload.size() - 2] = 0;
+                        sftmm1a_debug << std::string((char *)&pkt.payload[STREAM_HEADER_SKIP]) << std::endl;
+                        break;
+
+                    case MAGIC_MARKER_SFTMM1C_DEBUG:
+                        pkt.payload[pkt.payload.size() - 1] = 0;
+                        pkt.payload[pkt.payload.size() - 2] = 0;
+                        sftmm1c_debug << std::string((char *)&pkt.payload[STREAM_HEADER_SKIP]) << std::endl;
+                        break;
+
+                #if 0
+                    case 0x0012FA08D0480108:
+                        // logger->info(pkt.payload.size());
+
+                        //     data_out.put(0x1a);
+                        //     data_out.put(0xcf);
+                        //      data_out.put(0xfc);
+                        //      data_out.put(0x1d);
+                        //      data_out.write((char *)pkt.payload.data(), pkt.payload.size());
+                #endif
+
+                    default:
+                        break;
+                };
             }
+
             progress = data_in.tellg();
             if (time(NULL) % 10 == 0 && lastTime != time(NULL))
             {
@@ -129,7 +185,11 @@ namespace spacex
             }
         }
 
+#ifdef USE_VIDEO_ENCODER
+        videoStreamEnc->streamFinished();
+#else
         video_out.close();
+#endif
         gps_debug_out.close();
         sfc1a_debug.close();
         sftmm1a_debug.close();

--- a/src-core/modules/spacex/module_falcon_decoder.h
+++ b/src-core/modules/spacex/module_falcon_decoder.h
@@ -4,26 +4,33 @@
 #include <complex>
 #include <fstream>
 #include <dsp/random.h>
+#include "falcon_video_encoder.hpp"
 
 namespace spacex
 {
     class FalconDecoderModule : public ProcessingModule
     {
-    protected:
-        std::ifstream data_in;
-        std::ofstream data_out;
-        std::atomic<size_t> filesize;
-        std::atomic<size_t> progress;
-
     public:
         FalconDecoderModule(std::string input_file, std::string output_file_hint, std::map<std::string, std::string> parameters);
         ~FalconDecoderModule();
         void process();
         void drawUI(bool window);
 
+    protected:
+        std::ifstream data_in;
+        std::ofstream data_out;
+        std::atomic<size_t> filesize;
+        std::atomic<size_t> progress;
+
+
     public:
         static std::string getID();
         static std::vector<std::string> getParameters();
         static std::shared_ptr<ProcessingModule> getInstance(std::string input_file, std::string output_file_hint, std::map<std::string, std::string> parameters);
+
+    private:
+#ifdef USE_VIDEO_ENCODER
+        std::unique_ptr<FalconVideoEncoder> videoStreamEnc;
+#endif
     };
 } // namespace falcon


### PR DESCRIPTION
I know that this is a little bit outdated since the Falcon9 stream is currently encoded.
But @Aang23 suggested adding this code since it's a lot of work was done.

Probably this module can be used for some other/future video feed. Currently, it's in the Falcon decoder module but can be moved and renamed. 
**The module is not specific for the Falcon or SpaceX or any specific format** It's based on libavformat/libavcodec and can read any input video feed and convert it to an h264 mp4 file with real-time text overlay (optionally).
The module automatically detects all video and KLV data streams. Each stream's data will be saved in a separate file:
video_0.mp4, video_1.mp4, data_0.klv, and so on.

Damaged frames are dropped so the resulting file can be played with any player.
![image](https://user-images.githubusercontent.com/699871/114096361-49dbfd80-98c7-11eb-87b2-6b05bf639841.png)

**I introduced a new condition macro "USE_VIDEO_ENCODER" which is set by default.
This macro can be used to disable compilation and usage of the video coder module.
Please note that in the case of the disabled module we need to disable libav* dependencies in src-core/CMakeLists.txt. This is not done here.**