### PR TITLE
Add peak SNR readout to all demodulators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ android/.gradle
 android/SatDump/build
 android/SatDump/assets
 android/.idea
+**/.DS_Store

--- a/src-core/common/widgets/snr_plot.cpp
+++ b/src-core/common/widgets/snr_plot.cpp
@@ -1,0 +1,33 @@
+#include "module.h"
+#include <array>
+#include <cstring>
+#include "snr_plot.h"
+
+namespace widgets {
+
+
+    void SNRPlotViewer::draw(float snr, float peak_snr) {
+
+
+        ImGui::Button("Signal", {200 * ui_scale, 20 * ui_scale});
+        {
+            ImGui::Text("SNR (dB) : ");
+            ImGui::SameLine();
+            ImGui::TextColored(snr > 2 ? snr > 10 ? IMCOLOR_SYNCED : IMCOLOR_SYNCING : IMCOLOR_NOSYNC, UITO_C_STR(snr));
+            
+            ImGui::Text("Peak SNR (dB) : ");
+            ImGui::SameLine();
+            ImGui::TextColored(peak_snr > 2 ? peak_snr > 10 ? IMCOLOR_SYNCED : IMCOLOR_SYNCING : IMCOLOR_NOSYNC, UITO_C_STR(peak_snr));
+
+            std::memmove(&snr_history[0], &snr_history[1], (200 - 1) * sizeof(float));
+            snr_history[200 - 1] = snr;
+
+            ImGui::PlotLines("", snr_history, IM_ARRAYSIZE(snr_history), 0, "", 0.0f, 25.0f, ImVec2(200 * ui_scale, 50 * ui_scale));
+        }
+
+
+    }
+
+
+
+}

--- a/src-core/common/widgets/snr_plot.h
+++ b/src-core/common/widgets/snr_plot.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "imgui/imgui.h"
+#include "complex"
+
+namespace widgets 
+{
+    class SNRPlotViewer {
+        
+        private:
+        float snr_history[200];
+
+        public:
+            void draw(float snr = 1, float peak_snr = 1);
+
+    };
+}

--- a/src-core/modules/meteor/module_meteor_hrpt_demod.cpp
+++ b/src-core/modules/meteor/module_meteor_hrpt_demod.cpp
@@ -17,6 +17,7 @@ namespace meteor
         // Buffers
         bits_buffer = new uint8_t[d_buffer_size * 10];
         snr = 0;
+        peak_snr = 0;
     }
 
     void METEORHRPTDemodModule::init()
@@ -100,6 +101,10 @@ namespace meteor
             // Estimate SNR, only on part of the samples to limit CPU usage
             snr_estimator.update((std::complex<float> *)rec->output_stream->readBuf, dat_size / 100);
             snr = snr_estimator.snr();
+            
+            if (snr > peak_snr) {
+                peak_snr = snr;
+            }
 
             volk_32f_binary_slicer_8i((int8_t *)bits_buffer, rec->output_stream->readBuf, dat_size);
 
@@ -155,17 +160,8 @@ namespace meteor
 
         ImGui::BeginGroup();
         {
-            ImGui::Button("Signal", {200 * ui_scale, 20 * ui_scale});
-            {
-                ImGui::Text("SNR (dB) : ");
-                ImGui::SameLine();
-                ImGui::TextColored(snr > 2 ? snr > 10 ? IMCOLOR_SYNCED : IMCOLOR_SYNCING : IMCOLOR_NOSYNC, UITO_C_STR(snr));
-
-                std::memmove(&snr_history[0], &snr_history[1], (200 - 1) * sizeof(float));
-                snr_history[200 - 1] = snr;
-
-                ImGui::PlotLines("", snr_history, IM_ARRAYSIZE(snr_history), 0, "", 0.0f, 25.0f, ImVec2(200 * ui_scale, 50 * ui_scale));
-            }
+            // Show SNR information
+            snr_plot.draw(snr, peak_snr);
         }
         ImGui::EndGroup();
 

--- a/src-core/modules/meteor/module_meteor_hrpt_demod.h
+++ b/src-core/modules/meteor/module_meteor_hrpt_demod.h
@@ -14,6 +14,7 @@
 #include "common/dsp/bpsk_carrier_pll.h"
 #include "common/widgets/constellation.h"
 #include "common/snr_estimator.h"
+#include "common/widgets/snr_plot.h"
 
 namespace meteor
 {
@@ -44,10 +45,11 @@ namespace meteor
 
         M2M4SNREstimator snr_estimator;
         float snr;
+        float peak_snr;
 
         // UI Stuff
-        float snr_history[200];
         widgets::ConstellationViewer constellation;
+        widgets::SNRPlotViewer snr_plot;
 
     public:
         METEORHRPTDemodModule(std::string input_file, std::string output_file_hint, std::map<std::string, std::string> parameters);

--- a/src-core/modules/module_bpsk_demod.cpp
+++ b/src-core/modules/module_bpsk_demod.cpp
@@ -20,6 +20,7 @@ BPSKDemodModule::BPSKDemodModule(std::string input_file, std::string output_file
     // Buffers
     sym_buffer = new int8_t[d_buffer_size * 2];
     snr = 0;
+    peak_snr = 0;
 }
 
 void BPSKDemodModule::init()
@@ -123,6 +124,10 @@ void BPSKDemodModule::process()
         // Estimate SNR, only on part of the samples to limit CPU usage
         snr_estimator.update(rec->output_stream->readBuf, dat_size / 100);
         snr = snr_estimator.snr();
+        
+        if (snr > peak_snr) {
+            peak_snr = snr;
+        }
 
         for (int i = 0; i < dat_size; i++)
         {
@@ -145,7 +150,7 @@ void BPSKDemodModule::process()
         if (time(NULL) % 10 == 0 && lastTime != time(NULL))
         {
             lastTime = time(NULL);
-            logger->info("Progress " + std::to_string(round(((float)progress / (float)filesize) * 1000.0f) / 10.0f) + "%, SNR : " + std::to_string(snr) + "dB");
+            logger->info("Progress " + std::to_string(round(((float)progress / (float)filesize) * 1000.0f) / 10.0f) + "%, SNR : " + std::to_string(snr) + "dB," + " Peak SNR: " + std::to_string(peak_snr) + "dB");
         }
     }
 
@@ -187,17 +192,8 @@ void BPSKDemodModule::drawUI(bool window)
 
     ImGui::BeginGroup();
     {
-        ImGui::Button("Signal", {200 * ui_scale, 20 * ui_scale});
-        {
-            ImGui::Text("SNR (dB) : ");
-            ImGui::SameLine();
-            ImGui::TextColored(snr > 2 ? snr > 10 ? IMCOLOR_SYNCED : IMCOLOR_SYNCING : IMCOLOR_NOSYNC, UITO_C_STR(snr));
-
-            std::memmove(&snr_history[0], &snr_history[1], (200 - 1) * sizeof(float));
-            snr_history[200 - 1] = snr;
-
-            ImGui::PlotLines("", snr_history, IM_ARRAYSIZE(snr_history), 0, "", 0.0f, 25.0f, ImVec2(200 * ui_scale, 50 * ui_scale));
-        }
+        // Show SNR information
+        snr_plot.draw(snr, peak_snr);
     }
     ImGui::EndGroup();
 

--- a/src-core/modules/module_bpsk_demod.h
+++ b/src-core/modules/module_bpsk_demod.h
@@ -13,6 +13,7 @@
 #include "common/dsp/rational_resampler.h"
 #include "common/snr_estimator.h"
 #include "common/widgets/constellation.h"
+#include "common/widgets/snr_plot.h"
 
 class BPSKDemodModule : public ProcessingModule
 {
@@ -55,10 +56,11 @@ protected:
 
     M2M4SNREstimator snr_estimator;
     float snr;
+    float peak_snr;
 
     // UI Stuff
-    float snr_history[200];
     widgets::ConstellationViewer constellation;
+    widgets::SNRPlotViewer snr_plot;
 
 public:
     BPSKDemodModule(std::string input_file, std::string output_file_hint, std::map<std::string, std::string> parameters);

--- a/src-core/modules/module_oqpsk_demod.cpp
+++ b/src-core/modules/module_oqpsk_demod.cpp
@@ -27,6 +27,7 @@ OQPSKDemodModule::OQPSKDemodModule(std::string input_file, std::string output_fi
     // Buffers
     sym_buffer = new int8_t[d_buffer_size * 2];
     snr = 0;
+    peak_snr = 0;
 }
 
 void OQPSKDemodModule::init()
@@ -133,6 +134,10 @@ void OQPSKDemodModule::process()
         // Estimate SNR, only on part of the samples to limit CPU usage
         snr_estimator.update(rec->output_stream->readBuf, dat_size / 100);
         snr = snr_estimator.snr();
+        
+        if (snr > peak_snr) {
+            peak_snr = snr;
+        }
 
         for (int i = 0; i < dat_size; i++)
         {
@@ -155,7 +160,7 @@ void OQPSKDemodModule::process()
         if (time(NULL) % 10 == 0 && lastTime != time(NULL))
         {
             lastTime = time(NULL);
-            logger->info("Progress " + std::to_string(round(((float)progress / (float)filesize) * 1000.0f) / 10.0f) + "%, SNR : " + std::to_string(snr) + "dB");
+            logger->info("Progress " + std::to_string(round(((float)progress / (float)filesize) * 1000.0f) / 10.0f) + "%, SNR : " + std::to_string(snr) + "dB," + " Peak SNR: " + std::to_string(peak_snr) + "dB");
         }
     }
 
@@ -198,17 +203,8 @@ void OQPSKDemodModule::drawUI(bool window)
 
     ImGui::BeginGroup();
     {
-        ImGui::Button("Signal", {200 * ui_scale, 20 * ui_scale});
-        {
-            ImGui::Text("SNR (dB) : ");
-            ImGui::SameLine();
-            ImGui::TextColored(snr > 2 ? snr > 10 ? IMCOLOR_SYNCED : IMCOLOR_SYNCING : IMCOLOR_NOSYNC, UITO_C_STR(snr));
-
-            std::memmove(&snr_history[0], &snr_history[1], (200 - 1) * sizeof(float));
-            snr_history[200 - 1] = snr;
-
-            ImGui::PlotLines("", snr_history, IM_ARRAYSIZE(snr_history), 0, "", 0.0f, 25.0f, ImVec2(200 * ui_scale, 50 * ui_scale));
-        }
+        // Show SNR information
+        snr_plot.draw(snr, peak_snr);
     }
     ImGui::EndGroup();
 

--- a/src-core/modules/module_oqpsk_demod.h
+++ b/src-core/modules/module_oqpsk_demod.h
@@ -14,6 +14,7 @@
 #include "common/dsp/rational_resampler.h"
 #include "common/snr_estimator.h"
 #include "common/widgets/constellation.h"
+#include "common/widgets/snr_plot.h"
 
 class OQPSKDemodModule : public ProcessingModule
 {
@@ -64,10 +65,11 @@ protected:
 
     M2M4SNREstimator snr_estimator;
     float snr;
+    float peak_snr;
 
     // UI Stuff
-    float snr_history[200];
     widgets::ConstellationViewer constellation;
+    widgets::SNRPlotViewer snr_plot;
 
 public:
     OQPSKDemodModule(std::string input_file, std::string output_file_hint, std::map<std::string, std::string> parameters);

--- a/src-core/modules/module_qpsk_demod.h
+++ b/src-core/modules/module_qpsk_demod.h
@@ -14,6 +14,7 @@
 #include "common/dsp/rational_resampler.h"
 #include "common/snr_estimator.h"
 #include "common/widgets/constellation.h"
+#include "common/widgets/snr_plot.h"
 
 class QPSKDemodModule : public ProcessingModule
 {
@@ -62,10 +63,11 @@ protected:
 
     M2M4SNREstimator snr_estimator;
     float snr;
+    float peak_snr;
 
     // UI Stuff
-    float snr_history[200];
     widgets::ConstellationViewer constellation;
+    widgets::SNRPlotViewer snr_plot;
 
 public:
     QPSKDemodModule(std::string input_file, std::string output_file_hint, std::map<std::string, std::string> parameters);

--- a/src-core/modules/noaa/module_noaa_dsb_demod.h
+++ b/src-core/modules/noaa/module_noaa_dsb_demod.h
@@ -16,6 +16,7 @@
 #include "dsb_deframer.h"
 #include "common/widgets/constellation.h"
 #include "common/snr_estimator.h"
+#include "common/widgets/snr_plot.h"
 
 namespace noaa
 {
@@ -51,10 +52,11 @@ namespace noaa
 
         M2M4SNREstimator snr_estimator;
         float snr;
+        float peak_snr;
 
         // UI Stuff
-        float snr_history[200];
         widgets::ConstellationViewer constellation;
+        widgets::SNRPlotViewer snr_plot;
 
     public:
         NOAADSBDemodModule(std::string input_file, std::string output_file_hint, std::map<std::string, std::string> parameters);

--- a/src-core/modules/noaa/module_noaa_hrpt_demod.cpp
+++ b/src-core/modules/noaa/module_noaa_hrpt_demod.cpp
@@ -17,6 +17,7 @@ namespace noaa
         // Buffers
         bits_buffer = new uint8_t[d_buffer_size * 10];
         snr = 0;
+        peak_snr = 0;
     }
 
     void NOAAHRPTDemodModule::init()
@@ -99,6 +100,10 @@ namespace noaa
             // Estimate SNR, only on part of the samples to limit CPU usage
             snr_estimator.update((std::complex<float> *)rec->output_stream->readBuf, dat_size / 100);
             snr = snr_estimator.snr();
+            
+            if (snr > peak_snr) {
+                peak_snr = snr;
+            }
 
             volk_32f_binary_slicer_8i((int8_t *)bits_buffer, rec->output_stream->readBuf, dat_size);
 
@@ -155,17 +160,8 @@ namespace noaa
 
         ImGui::BeginGroup();
         {
-            ImGui::Button("Signal", {200 * ui_scale, 20 * ui_scale});
-            {
-                ImGui::Text("SNR (dB) : ");
-                ImGui::SameLine();
-                ImGui::TextColored(snr > 2 ? snr > 10 ? IMCOLOR_SYNCED : IMCOLOR_SYNCING : IMCOLOR_NOSYNC, UITO_C_STR(snr));
-
-                std::memmove(&snr_history[0], &snr_history[1], (200 - 1) * sizeof(float));
-                snr_history[200 - 1] = snr;
-
-                ImGui::PlotLines("", snr_history, IM_ARRAYSIZE(snr_history), 0, "", 0.0f, 25.0f, ImVec2(200 * ui_scale, 50 * ui_scale));
-            }
+            // Show SNR information
+            snr_plot.draw(snr, peak_snr);
 
             ImGui::Button("Deframer", {200 * ui_scale, 20 * ui_scale});
             {

--- a/src-core/modules/noaa/module_noaa_hrpt_demod.h
+++ b/src-core/modules/noaa/module_noaa_hrpt_demod.h
@@ -13,6 +13,7 @@
 #include "noaa_deframer.h"
 #include "common/widgets/constellation.h"
 #include "common/snr_estimator.h"
+#include "common/widgets/snr_plot.h"
 
 namespace noaa
 {
@@ -45,10 +46,11 @@ namespace noaa
 
         M2M4SNREstimator snr_estimator;
         float snr;
+        float peak_snr;
 
         // UI Stuff
-        float snr_history[200];
         widgets::ConstellationViewer constellation;
+        widgets::SNRPlotViewer snr_plot;
 
     public:
         NOAAHRPTDemodModule(std::string input_file, std::string output_file_hint, std::map<std::string, std::string> parameters);

--- a/src-core/modules/terra/module_terra_db_demod.cpp
+++ b/src-core/modules/terra/module_terra_db_demod.cpp
@@ -24,6 +24,7 @@ namespace terra
         // Buffers
         sym_buffer = new int8_t[d_buffer_size * 2];
         snr = 0;
+        peak_snr = 0;
     }
 
     std::vector<ModuleDataType> TerraDBDemodModule::getInputTypes()
@@ -78,6 +79,10 @@ namespace terra
             // Estimate SNR, only on part of the samples to limit CPU usage
             snr_estimator.update(rec->output_stream->readBuf, dat_size / 100);
             snr = snr_estimator.snr();
+            
+            if (snr > peak_snr) {
+            peak_snr = snr;
+            }
 
             for (int i = 0; i < dat_size; i++)
             {
@@ -92,7 +97,7 @@ namespace terra
             if (time(NULL) % 10 == 0 && lastTime != time(NULL))
             {
                 lastTime = time(NULL);
-                logger->info("Progress " + std::to_string(round(((float)progress / (float)filesize) * 1000.0f) / 10.0f) + "%, SNR : " + std::to_string(snr) + "dB");
+                logger->info("Progress " + std::to_string(round(((float)progress / (float)filesize) * 1000.0f) / 10.0f) + "%, SNR : " + std::to_string(snr) + "dB," + " Peak SNR: " + std::to_string(peak_snr) + "dB");
             }
         }
 
@@ -122,17 +127,8 @@ namespace terra
 
         ImGui::BeginGroup();
         {
-            ImGui::Button("Signal", {200 * ui_scale, 20 * ui_scale});
-            {
-                ImGui::Text("SNR (dB) : ");
-                ImGui::SameLine();
-                ImGui::TextColored(snr > 2 ? snr > 10 ? IMCOLOR_SYNCED : IMCOLOR_SYNCING : IMCOLOR_NOSYNC, UITO_C_STR(snr));
-
-                std::memmove(&snr_history[0], &snr_history[1], (200 - 1) * sizeof(float));
-                snr_history[200 - 1] = snr;
-
-                ImGui::PlotLines("", snr_history, IM_ARRAYSIZE(snr_history), 0, "", 0.0f, 25.0f, ImVec2(200 * ui_scale, 50 * ui_scale));
-            }
+            // Show SNR information
+            snr_plot.draw(snr, peak_snr);
         }
         ImGui::EndGroup();
 

--- a/src-core/modules/terra/module_terra_db_demod.h
+++ b/src-core/modules/terra/module_terra_db_demod.h
@@ -11,6 +11,7 @@
 #include "common/dsp/file_source.h"
 #include "common/snr_estimator.h"
 #include "common/widgets/constellation.h"
+#include "common/widgets/snr_plot.h"
 
 namespace terra
 {
@@ -45,10 +46,11 @@ namespace terra
 
         M2M4SNREstimator snr_estimator;
         float snr;
+        float peak_snr;
 
         // UI Stuff
-        float snr_history[200];
         widgets::ConstellationViewer constellation;
+        widgets::SNRPlotViewer snr_plot;
 
     public:
         TerraDBDemodModule(std::string input_file, std::string output_file_hint, std::map<std::string, std::string> parameters);


### PR DESCRIPTION
This PR adds a new readout to (hopefully) all demodulators which shows the peak SNR of the signal that is being demodulated.