### PR TITLE
Added some extra guidance on command line switches and also a -h/--help switch

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,6 +1,6 @@
 name: Windows Build
 
-on: [push, workflow_dispatch]
+on: [push]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,6 +1,6 @@
 name: Windows Build
 
-on: [push]
+on: [push, workflow_dispatch]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/src-cli/main.cpp
+++ b/src-cli/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
 
     initLogger();
 
-    if (argc < 6 || strcmp(argv[1], "-h") || strcmp(argv[1], "--help") == 0)
+    if (argc < 6 || strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)
     {
         logger->info("Usage : " + std::string(argv[0]) + " [downlink] [input_level] [input_file] [output_level] [output_file_or_directory] [additional options as required]");
         logger->info("Extra options : -samplerate [bits_per_second] -baseband_format [f32/i16/i8/w8] -dc_block -iq_swap");

--- a/src-cli/main.cpp
+++ b/src-cli/main.cpp
@@ -16,9 +16,10 @@ int main(int argc, char *argv[])
 
     initLogger();
 
-    if (argc < 6)
+    if (argc < 6 || strcmp(argc[1], "-h") || strcmp(argc[1], "--help") == 0)
     {
-        logger->info("Usage : " + std::string(argv[0]) + " [downlink] [input_level] [input_file] [output_level] [output_file_or_directory]");
+        logger->info("Usage : " + std::string(argv[0]) + " [downlink] [input_level] [input_file] [output_level] [output_file_or_directory] [additional options as required]");
+        logger->info("Extra options : -samplerate [bits_per_second] -baseband_format [f32/i16/i8/w8] -dc_block -iq_swap");
         exit(1);
     }
 

--- a/src-cli/main.cpp
+++ b/src-cli/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
 
     initLogger();
 
-    if (argc < 6 || strcmp(argc[1], "-h") || strcmp(argc[1], "--help") == 0)
+    if (argc < 6 || strcmp(argv[1], "-h") || strcmp(argv[1], "--help") == 0)
     {
         logger->info("Usage : " + std::string(argv[0]) + " [downlink] [input_level] [input_file] [output_level] [output_file_or_directory] [additional options as required]");
         logger->info("Extra options : -samplerate [bits_per_second] -baseband_format [f32/i16/i8/w8] -dc_block -iq_swap");

--- a/src-ui/main.cpp
+++ b/src-ui/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
     std::string output_file = "";
     std::map<std::string, std::string> parameters;
 
-    if (argc < 6 || strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0))
+    if (argc < 6 || strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)
     {
         logger->info("Usage : " + std::string(argv[0]) + " [downlink] [input_level] [input_file] [output_level] [output_file_or_directory] [additional options as required]");
         logger->info("Extra options : -samplerate [bits_per_second] -baseband_format [f32/i16/i8/w8] -dc_block -iq_swap");

--- a/src-ui/main.cpp
+++ b/src-ui/main.cpp
@@ -46,9 +46,10 @@ int main(int argc, char *argv[])
     std::string output_file = "";
     std::map<std::string, std::string> parameters;
 
-    if (argc < 6)
+    if (argc < 6 || strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0))
     {
-        logger->info("Usage : " + std::string(argv[0]) + " [downlink] [input_level] [input_file] [output_level] [output_file_or_directory]");
+        logger->info("Usage : " + std::string(argv[0]) + " [downlink] [input_level] [input_file] [output_level] [output_file_or_directory] [additional options as required]");
+        logger->info("Extra options : -samplerate [bits_per_second] -baseband_format [f32/i16/i8/w8] -dc_block -iq_swap");
         // exit(1);
     }
     else


### PR DESCRIPTION
Added a -h/--help switch and also added some extra explanatory text to the logger on command line switches. This came about after a friend didn't know how to turn on DC Blocking from the command line. Happy to take suggestions on changing what I have added to make it clearer.

We could also split up the help switch into a bigger, more useful set of guidance further down the line.