### PR TITLE
Fix compile error on windsat for all platforms

### DIFF
--- a/pipelines/composites/fengyun_mersill.json.inc
+++ b/pipelines/composites/fengyun_mersill.json.inc
@@ -32,5 +32,14 @@
         "corrected": true,
         "equalize": true,
         "normalize": true
+    },
+    "CH1-EQU": {
+        "channels": [
+            1
+        ],
+        "expression": "1 - ch1",
+        "corrected": true,
+        "equalize": true,
+        "normalize": true
     }
 }

--- a/src-core/modules/coriolis/instruments/windsat/windsat_reader.cpp
+++ b/src-core/modules/coriolis/instruments/windsat/windsat_reader.cpp
@@ -1,6 +1,16 @@
 #include "windsat_reader.h"
 #include "common/repack.h"
 
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define __bswap_16 OSSwapInt16
+#elif _WIN32
+#define __bswap_16 _byteswap_ushort
+#elif __ANDROID__
+#include <byteswap.h>
+#define __bswap_16 __swap16
+#endif
+
 namespace coriolis
 {
     namespace windsat


### PR DESCRIPTION
This PR fixes a compile error regarding bswap16 on all supported platforms. 