### PR TITLE
Add Content-Type header

### DIFF
--- a/src-ingestor/main.cpp
+++ b/src-ingestor/main.cpp
@@ -36,6 +36,7 @@ void http_handle(nng_aio *aio)
     nng_http_res *res;
     nng_http_res_alloc(&res);
     nng_http_res_copy_data(res, jsonstr.c_str(), jsonstr.size());
+    nng_http_res_set_header(res, "Content-Type", "application/json; charset=utf-8");
     nng_aio_set_output(aio, 0, res);
     nng_aio_finish(aio, 0);
 }


### PR DESCRIPTION
Added Content-Type header to avoid getting "not well-formed" error in Firefox when loading JSON file with XMLHttpRequest.