### PR TITLE
Changed default spyserver samplerate to next biggest

### DIFF
--- a/libsdr/sdr/spyserver.cpp
+++ b/libsdr/sdr/spyserver.cpp
@@ -64,17 +64,18 @@ void SDRSpyServer::start()
         for (int i = client->devInfo.MinimumIQDecimation; i <= (int)client->devInfo.DecimationStageCount; i++)
         {
             float samplerate = client->devInfo.MaximumSampleRate / (float)(1 << i);
+
+            if (stageToUse == client->devInfo.MinimumIQDecimation && samplerate < d_samplerate)
+            {
+                if (d_samplerate < samplerates.back())
+                {
+                    logger->warn("Desired samplerate not available. Using next biggest samplerate. ({})", samplerates.back());
+                }
+                stageToUse = samplerates.size() - 1;
+            }
+
             samplerates.push_back(samplerate);
             logger->trace(samplerate);
-        }
-
-        if (std::find(samplerates.begin(), samplerates.end(), d_samplerate) != samplerates.end())
-        {
-            stageToUse = std::find(samplerates.begin(), samplerates.end(), d_samplerate) - samplerates.begin();
-        }
-        else
-        {
-            logger->error("Desired samplerate not available. Default to max.");
         }
     }
 

--- a/libsdr/sdr/spyserver.cpp
+++ b/libsdr/sdr/spyserver.cpp
@@ -65,7 +65,7 @@ void SDRSpyServer::start()
         {
             float samplerate = client->devInfo.MaximumSampleRate / (float)(1 << i);
 
-            if (stageToUse == client->devInfo.MinimumIQDecimation && samplerate < d_samplerate)
+            if (stageToUse == client->devInfo.MinimumIQDecimation && samplerate < d_samplerate && samplerates.size() > 0)
             {
                 if (d_samplerate < samplerates.back())
                 {

--- a/libsdr/sdr/spyserver.cpp
+++ b/libsdr/sdr/spyserver.cpp
@@ -71,6 +71,7 @@ void SDRSpyServer::start()
                 {
                     logger->warn("Desired samplerate not available. Using next biggest samplerate. ({})", samplerates.back());
                 }
+                setSamplerate(samplerates.back());
                 stageToUse = samplerates.size() - 1;
             }
 


### PR DESCRIPTION
If the specified samplerate was not available, the default was the max. This change makes the default the next biggest samplerate to the one specified.