### PR TITLE
Show selected frequency preview in recorder/processing panel

### DIFF
--- a/src-interface/recorder/recorder.cpp
+++ b/src-interface/recorder/recorder.cpp
@@ -237,7 +237,7 @@ namespace satdump
                 Pipeline selected_pipeline = pipelines[pipeline_selector.pipeline_id];
                 if (selected_pipeline.preset.frequencies.size() > 0)
                 {
-                    if (ImGui::BeginCombo("Freq###presetscombo", ""))
+                    if (ImGui::BeginCombo("Freq###presetscombo", selected_pipeline.preset.frequencies[pipeline_preset_id].first.c_str()))
                     {
                         for (int n = 0; n < (int)selected_pipeline.preset.frequencies.size(); n++)
                         {


### PR DESCRIPTION
The dropdown to select a preset frequency always showed blank. Now it will show the name of the preset you have selected.