### PR TITLE
Added new composites

### DIFF
--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -250,6 +250,17 @@
                         "equation": "ch4",
                         "equalize": true,
                         "geo_correct": true
+                    },
+                    "Night Microphysics": {
+                        "equation": "(1-ch5)-(1-ch4),(1-ch4)-(1-ch3),(1-ch4)",
+                        "geo_correct": true,
+                        "equalize": true,
+                        "white_balance": true
+                    },
+                    "Day Microphysics": {
+                        "equation": "ch1, (1-ch3)^2.5,(1-ch4)",
+                        "geo_correct": true,
+                        "equalize": true
                     }
                 },
                 "project_channels": {
@@ -739,6 +750,20 @@
                     },
                     "543": {
                         "equation": "ch5, ch4, ch3"
+                    }
+                }
+            },
+            "mtvza": {
+                "handler": "image_handler",
+                "name": "MTVZA",
+                "rgb_composites": {
+                    "Basic False Color": {
+                        "equation": "ch1, ch8, ch15",
+                        "equalize": true
+                    },
+                    "Clouds Only": {
+                        "equation": "ch29, ch28, ch1",
+                        "equalize": true
                     }
                 }
             },


### PR DESCRIPTION
# AVHRR/3:
* Day microphysics (`ch1, (1-ch3)^2.5,(1-ch4)`), info [here](http://www.virtuallab.bom.gov.au/files/8014/4100/7389/DayMicrophysicsRGBTOTALoneslide_Compatibility_Mode.pdf), **does not look to spec on METOP** but is still useful, works very well on POES.
* Night time microphysics (`(1-ch5)-(1-ch4),(1-ch4)-(1-ch3),(1-ch4)`), info [here](https://www.star.nesdis.noaa.gov/goes/documents/QuickGuide_GOESR_NtMicroRGB_final.pdf), **must be white balanced or will look way off**, works very well on METOP and POES.

# MTVZA:

* Basic false color composite (`ch1, ch8, ch15`) info [here](http://d33.infospace.ru/d33_conf/sb2018t2/9-18.pdf)
* Cloud only (`ch29, ch28, ch1`) uses low and high bands to produce an image of only clouds (from LeanHRPT)

# Additional notes:
Day/night time microphysics will probably work well on GOES and JPSS, but are untested due to not having access to either of these satellites. **Neither work with MSU-MR** due to SWIR channel being of a different wavelength.