### PR TITLE
Fixed missing equalization on HIRS and AMSU

### DIFF
--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -736,13 +736,16 @@
                 "name": "AMSU-A",
                 "rgb_composites": {
                     "221": {
-                        "equation": "ch2, ch2, ch1"
+                        "equation": "ch2, ch2, ch1",
+                        "equalize": true
                     },
                     "421": {
-                        "equation": "ch4, ch2, ch1"
+                        "equation": "ch4, ch2, ch1",
+                        "equalize": true
                     },
                     "543": {
-                        "equation": "ch5, ch4, ch3"
+                        "equation": "ch5, ch4, ch3",
+                        "equalize": true
                     }
                 },
                 "project_channels": {
@@ -762,13 +765,16 @@
                 "name": "HIRS",
                 "rgb_composites": {
                     "221": {
-                        "equation": "ch2, ch2, ch1"
+                        "equation": "ch2, ch2, ch1",
+                        "equalize": true
                     },
                     "421": {
-                        "equation": "ch4, ch2, ch1"
+                        "equation": "ch4, ch2, ch1",
+                        "equalize": true
                     },
                     "543": {
-                        "equation": "ch5, ch4, ch3"
+                        "equation": "ch5, ch4, ch3",
+                        "equalize": true
                     }
                 }
             },


### PR DESCRIPTION
For some reason the equalization parameter was missing on HIRS and AMSU composites (but present on MHS), rendering them almost useless (I thought HIRS had finally given up the ghost on NOAA18 but later when receiving the DSB signal, it turns out it still works and it was just this simple mistake)