### PR TITLE
Added AMSU equivalents for MTVZA

### DIFF
--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -864,6 +864,14 @@
                 "handler": "image_handler",
                 "name": "MTVZA",
                 "rgb_composites": {
+                    "443 (AMSU 221 equivalent)": {
+                        "equation": "ch4, ch4, ch3",
+                        "equalize": true
+                    },
+                    "843 (AMSU 421 equivalent)": {
+                        "equation": "ch8, ch4, ch3",
+                        "equalize": true
+                    },
                     "Basic False Color": {
                         "equation": "ch1, ch8, ch15",
                         "equalize": true


### PR DESCRIPTION
new compos as discussed on the matrix. 

Can't support 543 due to incorrect frequency and noisy channel 3; 
Can't support ATMS 16-17-18 due to missing 88 and 165 GHz frequencies